### PR TITLE
Remove longjmp on failure and instead call the mbed-test-async handler.

### DIFF
--- a/module.json
+++ b/module.json
@@ -21,5 +21,7 @@
       "type": "MIT"
     }
   ],
-  "dependencies": {}
+  "dependencies": {
+      "mbed-test-async": "*"
+  }
 }

--- a/source/unity.c
+++ b/source/unity.c
@@ -5,10 +5,11 @@
 ============================================================================ */
 
 #include "unity/unity.h"
+#include "mbed-test-async/unity_handler.h"
 #include <stddef.h>
 
-#define UNITY_FAIL_AND_BAIL   { Unity.CurrentTestFailed  = 1; longjmp(Unity.AbortFrame, 1); }
-#define UNITY_IGNORE_AND_BAIL { Unity.CurrentTestIgnored = 1; longjmp(Unity.AbortFrame, 1); }
+#define UNITY_FAIL_AND_BAIL   { mbed_test_unity_assert_failure(); }
+#define UNITY_IGNORE_AND_BAIL { mbed_test_unity_assert_failure(); }
 /// return prematurely if we are already in failure or ignore state
 #define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} }
 #define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }

--- a/source/unity.c
+++ b/source/unity.c
@@ -8,8 +8,8 @@
 #include "mbed-test-async/unity_handler.h"
 #include <stddef.h>
 
-#define UNITY_FAIL_AND_BAIL   { mbed_test_unity_assert_failure(); }
-#define UNITY_IGNORE_AND_BAIL { mbed_test_unity_assert_failure(); }
+#define UNITY_FAIL_AND_BAIL   { UNITY_OUTPUT_CHAR('\n'); mbed_test_unity_assert_failure(); }
+#define UNITY_IGNORE_AND_BAIL { UNITY_OUTPUT_CHAR('\n'); mbed_test_unity_assert_failure(); }
 /// return prematurely if we are already in failure or ignore state
 #define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} }
 #define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }

--- a/source/unity.c
+++ b/source/unity.c
@@ -5,7 +5,7 @@
 ============================================================================ */
 
 #include "unity/unity.h"
-#include "mbed-test-async/unity_handler.h"
+#include "utest/unity_handler.h"
 #include <stddef.h>
 
 #define UNITY_FAIL_AND_BAIL   { UNITY_OUTPUT_CHAR('\n'); utest_unity_assert_failure(); }

--- a/source/unity.c
+++ b/source/unity.c
@@ -8,8 +8,8 @@
 #include "mbed-test-async/unity_handler.h"
 #include <stddef.h>
 
-#define UNITY_FAIL_AND_BAIL   { UNITY_OUTPUT_CHAR('\n'); mbed_test_unity_assert_failure(); }
-#define UNITY_IGNORE_AND_BAIL { UNITY_OUTPUT_CHAR('\n'); mbed_test_unity_assert_failure(); }
+#define UNITY_FAIL_AND_BAIL   { UNITY_OUTPUT_CHAR('\n'); utest_unity_assert_failure(); }
+#define UNITY_IGNORE_AND_BAIL { UNITY_OUTPUT_CHAR('\n'); utest_unity_assert_failure(); }
 /// return prematurely if we are already in failure or ignore state
 #define UNITY_SKIP_EXECUTION  { if ((Unity.CurrentTestFailed != 0) || (Unity.CurrentTestIgnored != 0)) {return;} }
 #define UNITY_PRINT_EOL       { UNITY_OUTPUT_CHAR('\n'); }


### PR DESCRIPTION
This PR depends on https://github.com/ARMmbed/mbed-test-async/pull/1.

It might be interesting to make this functionality a configuration option incase one does not want to use the mbed-test-async callback, but the original functionality.

@bogdanm @0xc0170 @bremoran
